### PR TITLE
css folder (cwd) bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-contrib-jshint": "~0.10.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "keywords" : [
     "grunt", "base64", "encodng", "data URI", "css", "images", "latency", "mobile"

--- a/tasks/grunt-encode-images.js
+++ b/tasks/grunt-encode-images.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
 						dirUps = img.match(/[^\/](\.[^.\/]*)/g).length;
 						img = img.replace('../','');
 						destDir = '';
-						for (i = 0; i < dirUps; i++) {
+						for (i = 0; i < (cssDirs.length - dirUps); i++) {
 							destDir += cssDirs[i] + '/';
 						}
 					}


### PR DESCRIPTION
thanks for your great grunt-plugin. 👍 

![image](https://user-images.githubusercontent.com/2696463/38913142-2d8b9c96-4314-11e8-8c4e-4efbd442f682.png)

there is bug for 'cwd'.
if 'cwd' folder has 2depth folder (like 'build/css/'), it's no problem,
but not 2depth (like 'app/client/css') it have problem. grunt-encode-images cannot find css file.
so, i fix it.

plz review it!